### PR TITLE
Add missing options field to SubscriptionList

### DIFF
--- a/rpc/proto/openconfig.proto
+++ b/rpc/proto/openconfig.proto
@@ -306,6 +306,7 @@ message SubscriptionList {
   message Options {
     bool use_aliases = 1;  // client accepts target defined aliases.
   }
+  Options options = 3;
 }
 
 // Subscription contains a path as well as the target side coalesce_interval for


### PR DESCRIPTION
As per Benoit's mail, actually include Options in the SubscriptionList message.
