### PR TITLE
Add support for PROTO message value type.

### DIFF
--- a/rpc/openconfig/openconfig.proto
+++ b/rpc/openconfig/openconfig.proto
@@ -230,6 +230,7 @@ message Value {
 enum Type {
   JSON = 0;
   BYTES = 1;
+  PROTO = 2;
 }
 
 // GetModelsRequest contains a list of models to return.  If no queries are


### PR DESCRIPTION
This change allows the bytes to be a serialized proto message
If the sender uses this encoding it is up to the receiver to
Understand the schema and properly decode the message.