### PR TITLE
rpc/openconfig: Upgrade to gRPC API v4.

### DIFF
--- a/rpc/openconfig/openconfig.pb.go
+++ b/rpc/openconfig/openconfig.pb.go
@@ -1440,7 +1440,7 @@ var _ grpc.ClientConn
 
 // This is a compile-time assertion to ensure that this generated file
 // is compatible with the grpc package it is being compiled against.
-const _ = grpc.SupportPackageIsVersion3
+const _ = grpc.SupportPackageIsVersion4
 
 // Client API for OpenConfig service
 
@@ -1669,7 +1669,7 @@ var _OpenConfig_serviceDesc = grpc.ServiceDesc{
 			ClientStreams: true,
 		},
 	},
-	Metadata: fileDescriptor0,
+	Metadata: "github.com/openconfig/reference/rpc/openconfig/openconfig.proto",
 }
 
 func init() {


### PR DESCRIPTION
This is needed as of grpc/grpc-go@727a60e4 / golang/protobuf@09b5638f.