### PR TITLE
gNMI: Update the generated Go code and add support for gRPC

### DIFF
--- a/rpc/gnmi/gen.go
+++ b/rpc/gnmi/gen.go
@@ -1,0 +1,17 @@
+//
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package gnmi
+
+//go:generate bash -c "cd $GOPATH/src && protoc --proto_path=. --go_out=plugins=grpc:. github.com/openconfig/reference/rpc/gnmi/gnmi.proto"


### PR DESCRIPTION
Without this, it's not possible to import this package in gRPC clients/servers, one would have to generate their own stubs instead of working off the upstream package, which is sad.