### PR TITLE
rpc/gnmi: Fix up the import path for descriptor.proto

### DIFF
--- a/rpc/gnmi/gen.go
+++ b/rpc/gnmi/gen.go
@@ -14,4 +14,4 @@
 // limitations under the License.
 package gnmi
 
-//go:generate bash -c "cd $GOPATH/src && protoc --proto_path=. --go_out=plugins=grpc:. github.com/openconfig/reference/rpc/gnmi/gnmi.proto"
+//go:generate bash -c "cd $GOPATH/src && protoc --proto_path=. --go_out=Mgithub.com/google/protobuf/src/google/protobuf/descriptor.proto=github.com/golang/protobuf/protoc-gen-go/descriptor,plugins=grpc:. github.com/openconfig/reference/rpc/gnmi/gnmi.proto"

--- a/rpc/gnmi/gnmi.pb.go
+++ b/rpc/gnmi/gnmi.pb.go
@@ -46,7 +46,7 @@ import proto "github.com/golang/protobuf/proto"
 import fmt "fmt"
 import math "math"
 import google_protobuf "github.com/golang/protobuf/ptypes/any"
-import google_protobuf1 "github.com/google/protobuf/src/google/protobuf"
+import google_protobuf1 "github.com/golang/protobuf/protoc-gen-go/descriptor"
 
 import (
 	context "golang.org/x/net/context"


### PR DESCRIPTION
Because it would be too simple if the generated Go code was alongside the C++ code in https://github.com/google/protobuf/tree/master/src/google/protobuf right?  :)