### PR TITLE
Remove the PDF specification link.

### DIFF
--- a/rpc/gnmi/README.md
+++ b/rpc/gnmi/README.md
@@ -11,8 +11,6 @@ The repository contents are as follows:
 
 
    * Specification for gNMI - [gnmi-specification.md](gnmi-specification.md).
-   * PDF of specification document
-     [gnmi-specification.pdf](gnmi-specification.pdf)
    * Authentication Specification for gNMI - [gnmi-authentication.md](gnmi-authentication.md)
    * Path Conventions for gNMI - [gnmi-path-conventions.md](gnmi-path-conventions.md)
    * gNMI Support for Multiple Client Roles and Master Arbitration - [gnmi-master-arbitration.md](gnmi-master-arbitration.md)


### PR DESCRIPTION
Internal cleanup to fix #98.