### PR TITLE
Proposal for clarifications when calling gNMI Set on a list node or element.

### DIFF
--- a/rpc/gnmi/gnmi-specification.md
+++ b/rpc/gnmi/gnmi-specification.md
@@ -470,13 +470,12 @@ update: <
     >
   >
   val: <
-    json_ietf_val: `{ "b": {
-                        "name": "b1",
-                        "c": {
-                          "d": "AStringValue",
-                          "e": 10042
-                        }
-                   }
+    json_ietf_val: `{ 
+                      "name": "b1",
+                      "c": {
+                        "d": "AStringValue",
+                        "e": 10042
+                      }
             }`
   >
 >
@@ -1138,7 +1137,7 @@ array), the following considerations apply:
 
 *   In the case that multiple attribute values are required to uniquely address
     an element - e.g., `/a/f[k1=10][k2=20] `- and a replace or update
-    operation's path specifies a strict subset of the attributes (e.g.,
+    operation's path specifies a proper subset of the attributes (e.g.,
     `/a/f[k1=10]`, `/a/f`), then this MUST be considered an error by the target
     system - and an status code of` InvalidArgument (3)` specified.
 *   Where the path specified refers to a node which itself represents the
@@ -1150,11 +1149,6 @@ array), the following considerations apply:
     as their own elements within the data tree, update or replace operations
     that modify instances of the key in conflicting ways MUST be considered an
     error. The target MUST return a status code of `InvalidArgument (3)`.
-*   In OpenConfig, a path which refers to a keyed YANG list node for
-    modification (as opposed to an element of the list node) MUST terminate at
-    the [enclosing
-    container](https://github.com/openconfig/public/blob/master/doc/openconfig_style_guide.md#list)
-    element.
 
 For example, consider a tree corresponding to the examples above, as illustrated
 below.


### PR DESCRIPTION
1. Add example JSON_IETF format for updating an individual list element.
1. Clarify that an empty subset of attributes for a keyed-list is unacceptable as a path for gNMI Set.
1. Clarify that in OpenConfig, MUST specify a path that terminates on the enclosing container in order to modify a whole list node.
1. Minor grammar fixes.

### Background
I found these points to be missing from either this doc or RFC7951 (#139). After some discussions with Anees, I'm proposing to add these clarifications that may or may not be the standard or established convention. In that case, modification suggestions are welcome to correct any inaccuracies.