### PR TITLE
Clarify that SubscribeResponse messages are not guaranteed to be in timestamp order.

### DIFF
--- a/rpc/gnmi/gnmi-specification.md
+++ b/rpc/gnmi/gnmi-specification.md
@@ -1434,6 +1434,11 @@ established `Subscribe` RPC. The message contains the following fields:
 *   `extension` - a repeated field used to carry gNMI extensions, as per the
     description in [Section 2.7](#27-extensions-to-gnmi).
 
+`SubscribeResponse` messages with the `update` field set to a `Notification`
+message are not guaranteed to be sent in timestamp order. This allows congestion
+management schemes to provide the most recent data while avoiding starving any
+particular path.
+
 #### 3.5.1.5 Creating Subscriptions
 
 ##### 3.5.1.5.1 ONCE Subscriptions

--- a/rpc/gnmi/gnmi-specification.md
+++ b/rpc/gnmi/gnmi-specification.md
@@ -1434,10 +1434,10 @@ established `Subscribe` RPC. The message contains the following fields:
 *   `extension` - a repeated field used to carry gNMI extensions, as per the
     description in [Section 2.7](#27-extensions-to-gnmi).
 
-`SubscribeResponse` messages with the `update` field set to a `Notification`
-message are not guaranteed to be sent in timestamp order. This allows congestion
-management schemes to provide the most recent data while avoiding starving any
-particular path.
+`SubscribeResponse` messages with the `update` field set to a `Notification` are
+not required to be sent by the target in timestamp order, and client
+implementations MUST NOT assume that these messages will be received in
+timestamp order.
 
 #### 3.5.1.5 Creating Subscriptions
 


### PR DESCRIPTION
I put this as another paragraph under "The SubscribeResponse Message". Let me know if you'd like this to be in a separate section.

FIXED #145