### PR TITLE
gnmi: standardise metadata username/password keys

### DIFF
--- a/rpc/gnmi/gnmi-authentication.md
+++ b/rpc/gnmi/gnmi-authentication.md
@@ -55,6 +55,19 @@ performant solution.
 Subscribe and Get RPCs do not make configuration changes to a device and thus should be allowed for users with Read-Only or
 Read-Write permissions.
 
+#### Metadata standards
+<ul>
+gRPC specifies <a href="https://grpc.io/docs/what-is-grpc/core-concepts/#metadata">metadata</a> as a list of arbitrary key/value pairs.<br>
+The following metadata key/value pairs are therefore standardised across gNMI/gNOI for cases where metadata is involved in authentication:
+
+| Key          | Value           |
+|--------------|-----------------|
+| `"username"` | client username |
+| `"password"` | client password |
+</ul>
+
+
+
 **Contributors**: Alex Bogdanov, Josh George, Carl Lebsack, Chris Morrow, Anees Shaikh, Rob Shakir
 
 ## Appendix - gRPC Authentication Flow Diagram


### PR DESCRIPTION
Currently, there is no standard for what keys should be used in the metadata to identify gNMI/gNOI username and password when doing authentication.

By convention, the username and password are provided in the metadata with keys "username" and "password".
(see examples below).
It would be good to formalise this into the gNMI authentication reference spec here so that gNMI clients and servers can both be designed with this consensus.

Some examples of current gNMI clients providing "username" and "password" as keys in metadata:

1. gnmi_cli client: https://github.com/openconfig/gnmi/blob/d5360e33fc3b22effeaaaf55f345c1f950765bed/client/gnmi/credentials.go#L35

2. goarista client: https://github.com/aristanetworks/goarista/blob/6112fea8c7e028c64ae52412952b0a2142b8c2e9/gnmi/client.go#L311

3. gnmic client: https://github.com/karimra/gnmic/blob/d1b198f67a99fe2f228d6119569310ebb1a50be3/target/target.go#L140 
Also note the other usages of
`metadata.AppendToOutgoingContext(ctx, "username", *t.Config.Username)` and
`metadata.AppendToOutgoingContext(ctx, "password", *t.Config.Password)`

4. pygnmi client https://github.com/akarneliuk/pygnmi/blob/3090d23ae32658026a244390a296f6ade01e9fb3/pygnmi/client.py#L54