### PR TITLE
Fix numbering scheme in union replace

### DIFF
--- a/rpc/gnmi/gnmi-union_replace.md
+++ b/rpc/gnmi/gnmi-union_replace.md
@@ -291,13 +291,13 @@ are:
    management port and that protocols like BGP and ISIS are not instantiated and
    therefore are also not enabled.
 
-When using union_replace, the user is expecting to assert all configuration
+    When using union_replace, the user is expecting to assert all configuration
 items needed to ensure the device has the intended state. For example, if a
 device factory default configuration includes an admin account and the user
 wants this removed, the user must include the negation of that user in the
-union_replace.
+union_replace.  
 
-If using NY origin, create a candidate configuration using the current running
+    If using NY origin, create a candidate configuration using the current running
 configuration.  Because a NY origin has a path structure, the user can control
 which portion of the tree should be replaced, including the entire NY tree.
 


### PR DESCRIPTION
Hi @dplore 

The numbering scheme is not correct, it seems. Let me know if that was not the original intention. 

This PR fixes the numbering to be rendered like this:
<img width="1054" alt="image" src="https://github.com/openconfig/reference/assets/5679861/48cd66db-f0f7-493c-81bf-18cac7a61220">
