### PR TITLE
Clarify that updating a leaf-list is semantically equivalent to replace.

### DIFF
--- a/rpc/gnmi/gnmi-specification.md
+++ b/rpc/gnmi/gnmi-specification.md
@@ -1059,7 +1059,9 @@ A `SetRequest` message consists of the following fields:
 - `replace`  - A set of `Update` messages indicating elements of the data tree
     whose content is to be replaced.
 - `update` - A set of `Update` messages indicating elements of the data tree
-    whose content is to be updated.
+    whose content is to be updated. Note that `leaflist_val` acts as a single,
+    cohesive ordered list of values; therefore, updates to it MUST replace,
+    rather than append, to the list.
 - `extension` - a repeated field used to carry gNMI extensions, as per the
     description in [Section 2.7](#27-extensions-to-gnmi).
 


### PR DESCRIPTION
This makes sense because in general the order matters, and append is just one way of inserting elements to the list. There is also no way to delete elements if this weren't the semantic.

ygot currently follows this.