### PR TITLE
gnmi on-change clarification

### DIFF
--- a/rpc/gnmi/gnmi-specification.md
+++ b/rpc/gnmi/gnmi-specification.md
@@ -1602,7 +1602,7 @@ with one of the following `modes`:
   - For all `ON_CHANGE` subscriptions, the target MUST first generate updates
       for all paths that match the subscription path(s), and transmit them.
       Following this initial set of updates, updated values SHOULD only be
-      transmitted when their value changes.
+      transmitted when their value changes with the exception of rapidly changing counter types.  Counter type values SHOULD be transmitted upon the initial subscription update and at each heartbeat_interval if one is specified.
   - A heartbeat interval MAY be specified along with an "on change"
       subscription - in this case, the value of the data item(s) MUST be re-sent
       once per heartbeat interval regardless of whether the value has changed or


### PR DESCRIPTION
Provide clarification to On Change for STREAM Subscription in section 3.5.1.5.2 to exclude rapidly changing counter types and only stream updates on the initial subscription and at the heartbeat interval if it has been specified.